### PR TITLE
Export to DOT & LaTex

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ENV PYTHONPATH=/app
 
 RUN apt-get update && apt-get install -y graphviz
 
-RUN pip install --no-cache-dir flask requests graphviz owlready2 Pillow
+RUN pip install --no-cache-dir flask requests graphviz owlready2 Pillow dot2tex
 
 EXPOSE 5000
 

--- a/dag.py
+++ b/dag.py
@@ -427,6 +427,18 @@ class OntoDAGVisualizer:
         output_path = graph.render(filename)
         print(f"{dag_type} visualization saved as: {output_path}")
 
+    def generate_dot_source(self, dag, color_mapping=None):
+        from graphviz import Digraph
+        dag_type = dag.__class__.__name__
+        graph = Digraph(comment=dag_type, format="dot")
+        graph.attr(rankdir=self.layout)
+
+        for node in dag.nodes.values():
+            self._render_node(graph, node, is_root=node.name == dag.root.name, color_mapping=color_mapping)
+
+        # Return the DOT source string
+        return graph.source
+
     def generate_image(self, dag, color_mapping=None):
         from graphviz import Digraph
         from io import BytesIO

--- a/tests/testdag.py
+++ b/tests/testdag.py
@@ -1,6 +1,8 @@
 import os
 import unittest
+
 from dag import OntoDAG, OntoDAGVisualizer, Item
+from dot2tex import dot2tex
 
 
 class TestOntoDAG(unittest.TestCase):
@@ -74,6 +76,13 @@ class TestOntoDAG(unittest.TestCase):
         self.assertTrue(os.path.isfile('ontodag_vis.png'))
         os.remove('ontodag_vis')
         os.remove('ontodag_vis.png')
+
+    def test_generate_dot_source_to_tex(self):
+        visualizer = OntoDAGVisualizer()
+        dot_source = visualizer.generate_dot_source(self.dag)
+        self.assertIsNotNone(dot_source)
+        tex_content = dot2tex(dot_source)
+        self.assertIsNotNone(tex_content)
 
     def test_put_optimized(self):
         element_set_query = [self.ab, self.cd]

--- a/web/app.py
+++ b/web/app.py
@@ -248,6 +248,19 @@ def export_dag():
     return send_file(filename, as_attachment=True)
 
 
+@app.route("/dag/export/dot", methods=["GET"])
+def export_dag_dot():
+    my_dag = session["my_dag"]
+    visualizer = session["visualizer"]
+    dot_source = visualizer.generate_dot_source(my_dag)
+
+    tex_file = BytesIO(dot_source.encode('utf-8'))
+    tex_file.seek(0)
+    return send_file(tex_file, as_attachment=True,
+                     download_name='ontodag_export.dot',
+                     mimetype='application/x-dot')
+
+
 @app.route("/dag/export/tex", methods=["GET"])
 def export_dag_tex():
     my_dag = session["my_dag"]
@@ -270,6 +283,19 @@ def export_query_dag():
     owl = OWLOntology(filename)
     owl.export_dag(query_result_dag, filename, unique_id)
     return send_file(filename, as_attachment=True)
+
+
+@app.route("/dag/query/export/dot", methods=["GET"])
+def export_query_dag_dot():
+    query_result_dag = session["query_result_dag"]
+    visualizer = session["visualizer"]
+    dot_source = visualizer.generate_dot_source(query_result_dag)
+
+    tex_file = BytesIO(dot_source.encode('utf-8'))
+    tex_file.seek(0)
+    return send_file(tex_file, as_attachment=True,
+                     download_name='ontodag_query_export.dot',
+                     mimetype='application/x-dot')
 
 
 @app.route("/dag/query/export/tex", methods=["GET"])

--- a/web/app.py
+++ b/web/app.py
@@ -3,6 +3,7 @@ import uuid
 
 from dag import OntoDAG, Item, OntoDAGVisualizer
 from datetime import datetime, timedelta
+from dot2tex import dot2tex
 from flask import Flask, request, jsonify, render_template, send_file, session
 from flask.sessions import SessionInterface, SessionMixin
 from io import BytesIO
@@ -247,6 +248,20 @@ def export_dag():
     return send_file(filename, as_attachment=True)
 
 
+@app.route("/dag/export/tex", methods=["GET"])
+def export_dag_tex():
+    my_dag = session["my_dag"]
+    visualizer = session["visualizer"]
+    dot_source = visualizer.generate_dot_source(my_dag)
+    tex_content = dot2tex(dot_source)
+
+    tex_file = BytesIO(tex_content.encode('utf-8'))
+    tex_file.seek(0)
+    return send_file(tex_file, as_attachment=True,
+                     download_name='ontodag_export.tex',
+                     mimetype='application/x-tex')
+
+
 @app.route("/dag/query/export", methods=["GET"])
 def export_query_dag():
     query_result_dag = session["query_result_dag"]
@@ -255,6 +270,20 @@ def export_query_dag():
     owl = OWLOntology(filename)
     owl.export_dag(query_result_dag, filename, unique_id)
     return send_file(filename, as_attachment=True)
+
+
+@app.route("/dag/query/export/tex", methods=["GET"])
+def export_query_dag_tex():
+    query_result_dag = session["query_result_dag"]
+    visualizer = session["visualizer"]
+    dot_source = visualizer.generate_dot_source(query_result_dag)
+    tex_content = dot2tex(dot_source)
+
+    tex_file = BytesIO(tex_content.encode('utf-8'))
+    tex_file.seek(0)
+    return send_file(tex_file, as_attachment=True,
+                     download_name='ontodag_query_export.tex',
+                     mimetype='application/x-tex')
 
 
 @app.route("/")

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -20,12 +20,14 @@
         or
         <input type="file" id="file-input" name="file" />
         <button type="submit">Import File</button>
-        <button type="button" id="export-dag-button">Export DAG</button>
-        <button type="button" id="export-dag-tex-button">Export TEX</button>
+        Export
+        <button type="button" id="export-dag-button">DAG</button>
+        <button type="button" id="export-dag-dot-button">DOT</button>
+        <button type="button" id="export-dag-tex-button">TEX</button>
       </form>
       <form id="add-item-form">
-        <input type="text" id="subcategory" placeholder="Subcategory" size="12"/>
-        <input type="text" id="super-categories" placeholder="Super-categories (comma-separated)" size="30"/>
+        <input type="text" id="subcategory" placeholder="Subcategories (comma-separated)" size="30"/>
+        <input type="text" id="super-categories" placeholder="Super-categories (comma-separated)" size="34"/>
         <button type="submit">Add Item</button>
         <button type="button" id="remove-item-button">Remove Item</button>
       </form>
@@ -34,14 +36,16 @@
     </div>
     <div class="query-container container">
       <form id="query-form">
-        <input type="text" id="query-categories" placeholder="Super-categories (comma-separated)" size="30"/>
+        <input type="text" id="query-categories" placeholder="Super-categories (comma-separated)" size="50"/>
         <button type="submit">Query</button>
       </form>
       <form id="query-import-file-form" enctype="multipart/form-data">
        <input type="file" id="query-file-input" name="file" />
         <button type="submit">Import File</button>
-        <button type="button" id="export-query-dag-button">Export DAG</button>
-        <button type="button" id="export-query-dag-tex-button">Export TEX</button>
+        Export
+        <button type="button" id="export-query-dag-button">DAG</button>
+        <button type="button" id="export-query-dag-dot-button">DOT</button>
+        <button type="button" id="export-query-dag-tex-button">TEX</button>
       </form>
       <img id="dag-query-image" class="dag-visual" alt="DAG Visualization" style="display: none;"/>
       <div id="dag-query"></div>
@@ -214,12 +218,18 @@
       document.getElementById("export-dag-button").addEventListener("click", () => {
         window.location.href = "/dag/export";
       });
+      document.getElementById("export-dag-dot-button").addEventListener("click", () => {
+        window.location.href = "/dag/export/dot";
+      });
       document.getElementById("export-dag-tex-button").addEventListener("click", () => {
         window.location.href = "/dag/export/tex";
       });
 
       document.getElementById("export-query-dag-button").addEventListener("click", () => {
         window.location.href = "/dag/query/export";
+      });
+      document.getElementById("export-query-dag-dot-button").addEventListener("click", () => {
+        window.location.href = "/dag/query/export/dot";
       });
       document.getElementById("export-query-dag-tex-button").addEventListener("click", () => {
         window.location.href = "/dag/query/export/tex";

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -21,6 +21,7 @@
         <input type="file" id="file-input" name="file" />
         <button type="submit">Import File</button>
         <button type="button" id="export-dag-button">Export DAG</button>
+        <button type="button" id="export-dag-tex-button">Export TEX</button>
       </form>
       <form id="add-item-form">
         <input type="text" id="subcategory" placeholder="Subcategory" size="12"/>
@@ -40,6 +41,7 @@
        <input type="file" id="query-file-input" name="file" />
         <button type="submit">Import File</button>
         <button type="button" id="export-query-dag-button">Export DAG</button>
+        <button type="button" id="export-query-dag-tex-button">Export TEX</button>
       </form>
       <img id="dag-query-image" class="dag-visual" alt="DAG Visualization" style="display: none;"/>
       <div id="dag-query"></div>
@@ -212,9 +214,15 @@
       document.getElementById("export-dag-button").addEventListener("click", () => {
         window.location.href = "/dag/export";
       });
+      document.getElementById("export-dag-tex-button").addEventListener("click", () => {
+        window.location.href = "/dag/export/tex";
+      });
 
       document.getElementById("export-query-dag-button").addEventListener("click", () => {
         window.location.href = "/dag/query/export";
+      });
+      document.getElementById("export-query-dag-tex-button").addEventListener("click", () => {
+        window.location.href = "/dag/query/export/tex";
       });
 
       window.onload = loadDAG;


### PR DESCRIPTION
Export DAGs to DOT & LaTex
===

Adds feature to export OntoDAGs as DOT (graphviz) or LaTex format files.

## Features:

* Export OntoDAG to DOT format.
* Export OntoDAG to LaTex format.
* Web UI buttons to export OntoDAG (or result DAG) into a DOT or LaTex file.