### PR TITLE
feat: Manchester syntax OWL support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ENV PYTHONPATH=/app
 
 RUN apt-get update && apt-get install -y graphviz
 
-RUN pip install --no-cache-dir flask requests graphviz owlready2 Pillow dot2tex
+RUN pip install --no-cache-dir flask requests graphviz EMMOntoPy Pillow dot2tex
 
 EXPOSE 5000
 

--- a/owl.py
+++ b/owl.py
@@ -1,9 +1,15 @@
+import os
+import tempfile
 import types
 import uuid
 
 from dag import OntoDAG, Item
 from io import BytesIO
-from owlready2 import get_ontology, Thing
+try:
+    from ontopy import get_ontology
+except ImportError:
+    from owlready2 import get_ontology
+from owlready2 import Thing
 
 
 class OWLOntology:
@@ -36,16 +42,116 @@ class OWLOntology:
                     if Thing in sub_cls.is_a:
                         sub_cls.is_a.remove(Thing)
 
-        ontology.save(file=file_name)
+        ontology.save(filename=file_name, format="rdfxml")
+
+    @staticmethod
+    def generate_manchester_content(dag, unique_id=None) -> str:
+        """Generate Manchester OWL syntax content string from a DAG.
+
+        The root node ("*") is omitted; top-level nodes appear as classes with no
+        SubClassOf declaration (implicitly subclasses of owl:Thing).
+        """
+        if unique_id is None:
+            unique_id = str(uuid.uuid4())
+        urn_iri = f'urn:ontodag_{unique_id}'
+
+        topological_nodes = dag.topological_sort()
+
+        # Build parent map: child_name -> [parent_name, ...] (excluding the root)
+        parent_map = {node.name: [] for node in topological_nodes}
+        for node in topological_nodes:
+            if node.name == dag.root.name:
+                continue
+            for child in node.neighbors:
+                parent_map[child.name].append(node.name)
+
+        lines = [f'Ontology: <{urn_iri}>', '']
+
+        for node in topological_nodes:
+            if node.name == dag.root.name:
+                continue
+            lines.append(f'Class: {node.name}')
+            parents = parent_map[node.name]
+            if parents:
+                lines.append(f'    SubClassOf: {", ".join(parents)}')
+            lines.append('')
+
+        return '\n'.join(lines)
+
+    @staticmethod
+    def export_dag_manchester(dag, file_name="new_ontology.omn", unique_id=None):
+        """Export a DAG to Manchester OWL syntax (.omn) format."""
+        content = OWLOntology.generate_manchester_content(dag, unique_id)
+        with open(file_name, 'w', encoding='utf-8') as f:
+            f.write(content)
 
     def import_dag(self, file_name=None, file_content=None) -> OntoDAG:
         if not file_name and not file_content:
             raise ValueError("file_name or file_content must be provided")
-        if file_name:
-            with open(file_name, 'rb') as file:
-                file_content = BytesIO(file.read())
-        self.ontology.load(fileobj=file_content)
+        if file_content:
+            # ontopy's load() does not support fileobj; write to a temp file
+            raw = file_content.read() if hasattr(file_content, 'read') else file_content
+            with tempfile.NamedTemporaryFile(suffix='.owl', delete=False) as tmp:
+                tmp.write(raw)
+                tmp_path = tmp.name
+            try:
+                self.ontology = get_ontology(f"file://{tmp_path}").load()
+            finally:
+                os.unlink(tmp_path)
+        else:
+            self.ontology = get_ontology(f"file://{os.path.abspath(file_name)}").load()
         return self._process_dag()
+
+    @staticmethod
+    def import_dag_manchester(file_name=None, file_content=None) -> OntoDAG:
+        """Import a DAG from Manchester OWL syntax (.omn) format.
+
+        Accepts a file path, a BytesIO object, or raw bytes/str content.
+        Classes with no SubClassOf become direct children of the DAG root.
+        """
+        if file_name is None and file_content is None:
+            raise ValueError("file_name or file_content must be provided")
+
+        if file_name:
+            with open(file_name, 'r', encoding='utf-8') as f:
+                content = f.read()
+        else:
+            if isinstance(file_content, (bytes, bytearray)):
+                content = file_content.decode('utf-8')
+            elif hasattr(file_content, 'read'):
+                raw = file_content.read()
+                content = raw.decode('utf-8') if isinstance(raw, (bytes, bytearray)) else raw
+            else:
+                content = file_content
+
+        # Parse Class declarations and SubClassOf relationships
+        classes = {}  # name -> [parent_name, ...]
+        current_class = None
+
+        for line in content.splitlines():
+            stripped = line.strip()
+            if stripped.startswith('Class:'):
+                current_class = stripped[len('Class:'):].strip()
+                classes[current_class] = []
+            elif stripped.startswith('SubClassOf:') and current_class is not None:
+                parents_str = stripped[len('SubClassOf:'):].strip()
+                parents = [p.strip() for p in parents_str.split(',') if p.strip()]
+                classes[current_class].extend(parents)
+
+        dag = OntoDAG()
+        for name in classes:
+            dag.add_node(Item(name))
+
+        for name, parents in classes.items():
+            child = dag.nodes[name]
+            if parents:
+                for parent_name in parents:
+                    if parent_name in dag.nodes:
+                        dag.add_edge(dag.nodes[parent_name], child)
+            else:
+                dag.add_edge(dag.root, child)
+
+        return dag
 
     def _process_dag(self) -> OntoDAG:
         dag = OntoDAG()

--- a/owl.py
+++ b/owl.py
@@ -46,34 +46,34 @@ class OWLOntology:
 
     @staticmethod
     def generate_manchester_content(dag, unique_id=None) -> str:
-        """Generate Manchester OWL syntax content string from a DAG.
-
-        The root node ("*") is omitted; top-level nodes appear as classes with no
-        SubClassOf declaration (implicitly subclasses of owl:Thing).
-        """
+        """Generate Manchester OWL syntax content string from a DAG."""
         if unique_id is None:
             unique_id = str(uuid.uuid4())
         urn_iri = f'urn:ontodag_{unique_id}'
 
         topological_nodes = dag.topological_sort()
 
-        # Build parent map: child_name -> [parent_name, ...] (excluding the root)
+        # Build parent map: child_name -> [parent_name, ...] including root
         parent_map = {node.name: [] for node in topological_nodes}
         for node in topological_nodes:
-            if node.name == dag.root.name:
-                continue
             for child in node.neighbors:
                 parent_map[child.name].append(node.name)
 
-        lines = [f'Ontology: <{urn_iri}>', '']
+        lines = [
+            f'Prefix: : <{urn_iri}#>',
+            'Prefix: owl: <http://www.w3.org/2002/07/owl#>',
+            '',
+            f'Ontology: <{urn_iri}>',
+            '',
+        ]
 
         for node in topological_nodes:
-            if node.name == dag.root.name:
-                continue
-            lines.append(f'Class: {node.name}')
+            lines.append(f'Class: :{node.name}')
             parents = parent_map[node.name]
-            if parents:
-                lines.append(f'    SubClassOf: {", ".join(parents)}')
+            if node.name == dag.root.name:
+                lines.append('    SubClassOf: owl:Thing')
+            elif parents:
+                lines.append(f'    SubClassOf: {", ".join(":" + p for p in parents)}')
             lines.append('')
 
         return '\n'.join(lines)
@@ -124,6 +124,10 @@ class OWLOntology:
             else:
                 content = file_content
 
+        def _strip_prefix(name):
+            """Strip the local ':' prefix from a class name."""
+            return name[1:] if name.startswith(':') else name
+
         # Parse Class declarations and SubClassOf relationships
         classes = {}  # name -> [parent_name, ...]
         current_class = None
@@ -131,24 +135,36 @@ class OWLOntology:
         for line in content.splitlines():
             stripped = line.strip()
             if stripped.startswith('Class:'):
-                current_class = stripped[len('Class:'):].strip()
+                current_class = _strip_prefix(stripped[len('Class:'):].strip())
                 classes[current_class] = []
             elif stripped.startswith('SubClassOf:') and current_class is not None:
                 parents_str = stripped[len('SubClassOf:'):].strip()
-                parents = [p.strip() for p in parents_str.split(',') if p.strip()]
+                parents = [
+                    _strip_prefix(p.strip())
+                    for p in parents_str.split(',')
+                    if p.strip() and p.strip() != 'owl:Thing'
+                ]
                 classes[current_class].extend(parents)
 
         dag = OntoDAG()
+
+        # If the exported root class ('*') is present, wire it up as the DAG root
+        root_name = dag.root.name
         for name in classes:
+            if name == root_name:
+                continue  # root node already exists in dag
             dag.add_node(Item(name))
 
         for name, parents in classes.items():
+            if name == root_name:
+                continue  # root needs no incoming edges
             child = dag.nodes[name]
-            if parents:
-                for parent_name in parents:
-                    if parent_name in dag.nodes:
-                        dag.add_edge(dag.nodes[parent_name], child)
-            else:
+            non_root_parents = [p for p in parents if p != root_name and p in dag.nodes]
+            if non_root_parents:
+                for parent_name in non_root_parents:
+                    dag.add_edge(dag.nodes[parent_name], child)
+            elif not parents or all(p == root_name for p in parents):
+                # parent is root (explicit or implicit)
                 dag.add_edge(dag.root, child)
 
         return dag

--- a/tests/testowl.py
+++ b/tests/testowl.py
@@ -54,6 +54,66 @@ class TestOWLOntology(unittest.TestCase):
         self.assertIsNotNone(imported_dag)
         os.remove(test_filename)
 
+    def test_export_dag_manchester(self):
+        test_filename = "test_ontology.omn"
+        OWLOntology.export_dag_manchester(self.dag, test_filename)
+
+        self.assertTrue(os.path.isfile(test_filename))
+        with open(test_filename, 'r', encoding='utf-8') as f:
+            content = f.read()
+        self.assertIn('Ontology:', content)
+        self.assertIn('Class: A', content)
+        self.assertIn('Class: AB', content)
+        self.assertIn('SubClassOf: A', content)
+        os.remove(test_filename)
+
+    def test_import_dag_manchester(self):
+        test_filename = "test_ontology.omn"
+        OWLOntology.export_dag_manchester(self.dag, test_filename)
+
+        self.assertTrue(os.path.isfile(test_filename))
+        imported_dag = OWLOntology.import_dag_manchester(file_name=test_filename)
+
+        self.assertIsNotNone(imported_dag)
+        # All non-root nodes should be present
+        expected_names = {'A', 'B', 'C', 'D', 'F', 'G', 'AB', 'AF', 'BC', 'CD', 'ABC', 'ABF'}
+        imported_names = set(imported_dag.nodes.keys()) - {imported_dag.root.name}
+        self.assertEqual(imported_names, expected_names)
+        os.remove(test_filename)
+
+    def test_manchester_roundtrip_structure(self):
+        """Verify that SubClassOf relationships survive a Manchester export/import roundtrip."""
+        test_filename = "test_ontology.omn"
+        OWLOntology.export_dag_manchester(self.dag, test_filename)
+        imported_dag = OWLOntology.import_dag_manchester(file_name=test_filename)
+
+        # AB should have A and B as parents (neighbors of A and B point to AB)
+        ab_node = imported_dag.nodes.get('AB')
+        self.assertIsNotNone(ab_node)
+        a_node = imported_dag.nodes.get('A')
+        b_node = imported_dag.nodes.get('B')
+        self.assertIn(ab_node, a_node.neighbors)
+        self.assertIn(ab_node, b_node.neighbors)
+        os.remove(test_filename)
+
+    def test_generate_manchester_content(self):
+        content = OWLOntology.generate_manchester_content(self.dag)
+        self.assertIn('Ontology:', content)
+        # Root "*" should not appear
+        self.assertNotIn('Class: *', content)
+        # Top-level nodes have no SubClassOf
+        lines = content.splitlines()
+        class_lines = [l for l in lines if l.startswith('Class:')]
+        self.assertTrue(len(class_lines) > 0)
+
+    def test_import_dag_manchester_from_bytes(self):
+        content = OWLOntology.generate_manchester_content(self.dag)
+        imported_dag = OWLOntology.import_dag_manchester(file_content=content.encode('utf-8'))
+        self.assertIsNotNone(imported_dag)
+        expected_names = {'A', 'B', 'C', 'D', 'F', 'G', 'AB', 'AF', 'BC', 'CD', 'ABC', 'ABF'}
+        imported_names = set(imported_dag.nodes.keys()) - {imported_dag.root.name}
+        self.assertEqual(imported_names, expected_names)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/testowl.py
+++ b/tests/testowl.py
@@ -61,10 +61,14 @@ class TestOWLOntology(unittest.TestCase):
         self.assertTrue(os.path.isfile(test_filename))
         with open(test_filename, 'r', encoding='utf-8') as f:
             content = f.read()
+        self.assertIn('Prefix: : <', content)
+        self.assertIn('Prefix: owl: <http://www.w3.org/2002/07/owl#>', content)
         self.assertIn('Ontology:', content)
-        self.assertIn('Class: A', content)
-        self.assertIn('Class: AB', content)
-        self.assertIn('SubClassOf: A', content)
+        self.assertIn('Class: :*', content)
+        self.assertIn('SubClassOf: owl:Thing', content)
+        self.assertIn('Class: :A', content)
+        self.assertIn('Class: :AB', content)
+        self.assertIn('SubClassOf: :A', content)
         os.remove(test_filename)
 
     def test_import_dag_manchester(self):

--- a/web/app.py
+++ b/web/app.py
@@ -219,11 +219,13 @@ def import_dag():
         return jsonify({"error": "No selected file."}), 400
 
     file_content = BytesIO(file.read())
-
-    owl = OWLOntology(file.filename)
     my_dag = session["my_dag"]
     try:
-        imported_dag = owl.import_dag(file_content=file_content)
+        if file.filename.endswith('.omn'):
+            imported_dag = OWLOntology.import_dag_manchester(file_content=file_content)
+        else:
+            owl = OWLOntology(file.filename)
+            imported_dag = owl.import_dag(file_content=file_content)
         my_dag.merge(imported_dag)
         return jsonify({"message": "File imported and DAG created."}), 201
     except Exception as e:
@@ -263,6 +265,16 @@ def export_dag():
     return send_file(filename, as_attachment=True)
 
 
+@app.route("/dag/export/omn", methods=["GET"])
+def export_dag_manchester():
+    my_dag = session["my_dag"]
+    content = OWLOntology.generate_manchester_content(my_dag)
+    buf = BytesIO(content.encode('utf-8'))
+    buf.seek(0)
+    return send_file(buf, as_attachment=True, download_name='ontodag_export.omn',
+                     mimetype='text/plain')
+
+
 @app.route("/dag/export/dot", methods=["GET"])
 def export_dag_dot():
     my_dag = session["my_dag"]
@@ -298,6 +310,18 @@ def export_query_dag():
     owl = OWLOntology(filename)
     owl.export_dag(query_result_dag, filename, unique_id)
     return send_file(filename, as_attachment=True)
+
+
+@app.route("/dag/query/export/omn", methods=["GET"])
+def export_query_dag_manchester():
+    query_result_dag = session["query_result_dag"]
+    unique_id = str(uuid.uuid4())
+    content = OWLOntology.generate_manchester_content(query_result_dag, unique_id)
+    buf = BytesIO(content.encode('utf-8'))
+    buf.seek(0)
+    return send_file(buf, as_attachment=True,
+                     download_name=f'ontodag_query_export_{unique_id}.omn',
+                     mimetype='text/plain')
 
 
 @app.route("/dag/query/export/dot", methods=["GET"])

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -21,7 +21,8 @@
         <input type="file" id="file-input" name="file" />
         <button type="submit">Import File</button>
         Export
-        <button type="button" id="export-dag-button">DAG</button>
+        <button type="button" id="export-dag-button">OWL</button>
+        <button type="button" id="export-dag-omn-button">OMN</button>
         <button type="button" id="export-dag-dot-button">DOT</button>
         <button type="button" id="export-dag-tex-button">TEX</button>
       </form>
@@ -43,7 +44,8 @@
        <input type="file" id="query-file-input" name="file" />
         <button type="submit">Import File</button>
         Export
-        <button type="button" id="export-query-dag-button">DAG</button>
+        <button type="button" id="export-query-dag-button">OWL</button>
+        <button type="button" id="export-query-dag-omn-button">OMN</button>
         <button type="button" id="export-query-dag-dot-button">DOT</button>
         <button type="button" id="export-query-dag-tex-button">TEX</button>
       </form>
@@ -224,6 +226,9 @@
       document.getElementById("export-dag-button").addEventListener("click", () => {
         window.location.href = "/dag/export";
       });
+      document.getElementById("export-dag-omn-button").addEventListener("click", () => {
+        window.location.href = "/dag/export/omn";
+      });
       document.getElementById("export-dag-dot-button").addEventListener("click", () => {
         window.location.href = "/dag/export/dot";
       });
@@ -233,6 +238,9 @@
 
       document.getElementById("export-query-dag-button").addEventListener("click", () => {
         window.location.href = "/dag/query/export";
+      });
+      document.getElementById("export-query-dag-omn-button").addEventListener("click", () => {
+        window.location.href = "/dag/query/export/omn";
       });
       document.getElementById("export-query-dag-dot-button").addEventListener("click", () => {
         window.location.href = "/dag/query/export/dot";


### PR DESCRIPTION
## Supporting Manchester syntax for OWL import/export

Adding support to the [Manchester syntax](https://www.w3.org/TR/owl2-manchester-syntax/) for OWL in addition to the existing RDF/XML format.

It adds support to import DAGs in the web UI or programatically and also to export DAGs and query results on the web UI.

This can be valuable for multiple reasons:
* Less verbose
* More compact size leads to less storage cost and bandwidth requirements
* Using with LLMs: smaller context footprint, easier to navigate through associations and easier to edit
* Human-readable and easy to edit manually

### Manchester syntax example
```
  Prefix: : <urn:ontodag_...#>
  Prefix: owl: <http://www.w3.org/2002/07/owl#>

  Ontology: <urn:ontodag_...>

  Class: :*
      SubClassOf: owl:Thing

  Class: :A
      SubClassOf: :*

  Class: :AB
      SubClassOf: :A, :B
```
